### PR TITLE
Allow null as return type in Clock.php

### DIFF
--- a/src/common/Clock.php
+++ b/src/common/Clock.php
@@ -29,7 +29,7 @@ final class Clock {
      *
      * @return int
      */
-    public function unix(bool $real = false): int {
+    public function unix(bool $real = false): ?int {
         return __godlike_timestamp_cache($real)[2];
     }
 
@@ -38,7 +38,7 @@ final class Clock {
      *
      * @return int
      */
-    public function milli(bool $real = false): int {
+    public function milli(bool $real = false): ?int {
         return __godlike_timestamp_cache($real)[1];
     }
 
@@ -47,7 +47,7 @@ final class Clock {
      *
      * @return int
      */
-    public function micro(bool $real = false): int {
+    public function micro(bool $real = false): ?int {
         return __godlike_timestamp_cache($real)[0];
     }
 


### PR DESCRIPTION
Happens when godlike is running but not in use.